### PR TITLE
Remove LangVersion and improve BtnWrite_Click method

### DIFF
--- a/AutoText/AutoText.csproj
+++ b/AutoText/AutoText.csproj
@@ -16,7 +16,6 @@
     <SignAssembly>False</SignAssembly>
     <PackageProjectUrl>https://github.com/EdwinMarshalll/AutoText</PackageProjectUrl>
     <RepositoryUrl>https://github.com/EdwinMarshalll/AutoText</RepositoryUrl>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/AutoText/Form1.cs
+++ b/AutoText/Form1.cs
@@ -11,9 +11,10 @@ public partial class Form1 : Form
         this.MaximizeBox = false;
     }
 
-    private void BtnWrite_Click(object sender, EventArgs e)
+    private async void BtnWrite_Click(object sender, EventArgs e)
     {
-        Task.Delay((int)numericUpDown1.Value * 1000).Wait();
+        await Task.Delay((int)numericUpDown1.Value * 1000);
+
         values.TryGetValue(txtCombo.SelectedIndex, out string? texto);
 
         if (string.IsNullOrEmpty(texto)) return;
@@ -46,7 +47,10 @@ public partial class Form1 : Form
         if (index == null) return;
 
         values.TryAdd(index.Value, value);
-        txtCombo?.Text = string.Empty;
+        if(txtCombo is not null)
+        {
+            txtCombo.Text = string.Empty;
+        }
 
         e.Handled = true;
         e.SuppressKeyPress = true;


### PR DESCRIPTION
- Removed `<LangVersion>preview</LangVersion>` from `AutoText.csproj`.
- Changed `BtnWrite_Click` to be asynchronous, replacing synchronous delay with `await Task.Delay(...)` for better UI responsiveness.
- Added null check for `txtCombo` to prevent potential `NullReferenceException`.